### PR TITLE
FE - Updated UI labels and helper tooltips

### DIFF
--- a/Frontend/src/app/components/page-area/home/home.component.css
+++ b/Frontend/src/app/components/page-area/home/home.component.css
@@ -23,7 +23,10 @@ html, body {
   -moz-appearance: textfield;
   appearance: textfield;
 }
-
+.way{
+  display:flex;
+  flex-direction: column;
+}
 /* FORM MODAL */
 .overlay {
   display: flex;

--- a/Frontend/src/app/components/page-area/home/home.component.html
+++ b/Frontend/src/app/components/page-area/home/home.component.html
@@ -134,9 +134,10 @@
           <!-- Locations -->
           <div class="row">
             <div class="input-group">
-              <label>מיקום התחלה</label>
+              <label>מיקום התחלה</label> 
               <select formControlName="start_location">
-                <option value="">בחר עיר</option>
+                
+                <option class="way" value="">בחר עיר </option> 
                 <option *ngFor="let city of cities" [value]="city.id">{{ city.name }}</option>
               </select>
               <small *ngIf="f.start_location.touched && f.start_location.errors?.['required']" class="distance-info">חובה למלא מיקום התחלה</small>
@@ -145,7 +146,7 @@
             <div class="input-group">
               <label>תחנה</label>
               <select formControlName="stop">
-                <option value="">בחר עיר</option>
+                <option value="">בחר עיר (לדוג': ראשון לציון)</option>
                 <option *ngFor="let city of cities" [value]="city.id">{{ city.name }}</option>
               </select>
               <small *ngIf="f.stop.touched && f.stop.errors?.['required']" class="distance-info">חובה למלא תחנה</small>
@@ -158,11 +159,17 @@
                 <option *ngFor="let city of cities" [value]="city.id">{{ city.name }}</option>
               </select>
               <small *ngIf="f.destination.touched && f.destination.errors?.['required']" class="distance-info">חובה למלא יעד</small>
-            </div>
-          </div>
 
+            </div>
+                        
+          </div>
+<div class="row ">
+                              <small>נסיעתך תתחיל ותסתיים בבסיס הארגון: תל אביב</small>
+
+</div>
           <!-- Distance estimate -->
           <div class="row">
+
             <div class="input-group">
               <label>הערכת מרחק (ק"מ)</label>
               <input type="number" formControlName="estimated_distance_km" [readonly]="true" class="no-spinner"/>


### PR DESCRIPTION
FE - Update UI labels and helper tooltips 

Add small note below the destination field:
"Your ride will begin and end at the organization’s base: Tel Aviv."

For each stop field, show placeholder like: "Optional stop (e.g., Rishon LeZion)"

Add validation: if destination or any stop is empty, show error (they can delete one opened text field as they wish but if they didn’t delete the field- it shouldn’t be empty)